### PR TITLE
Allow external test runners to integrate more tightly with Saga

### DIFF
--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/DefaultCoverageGenerator.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/DefaultCoverageGenerator.java
@@ -65,6 +65,7 @@ final class DefaultCoverageGenerator implements CoverageGenerator {
             config.getNoInstrumentPatterns().add(INLINE_SCRIPT_RE);
             config.getNoInstrumentPatterns().add(".+JavaScriptStringJob");
             config.getNoInstrumentPatterns().add(".+#\\d+\\(eval\\)\\(\\d+\\)");
+            config.getNoInstrumentPatterns().add("injected script");
         }
 
         if (!config.getNoInstrumentPatterns().isEmpty()) {

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/TestRunCoverageStatisticsCallable.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/TestRunCoverageStatisticsCallable.java
@@ -56,7 +56,9 @@ class TestRunCoverageStatisticsCallable implements Callable<TestRunCoverageStati
                 throw e;
             }
         } finally {
-            if (localBrowser.get() != null) {
+        	// If browser was provided by external test runner, then
+        	// keep browser open so that test results can be read
+            if (localBrowser.get() != null && config.getInstrumentingBrowser() == null) {
                 logger.info("Quitting browser");
                 localBrowser.get().quit();
             }
@@ -99,11 +101,15 @@ class TestRunCoverageStatisticsCallable implements Callable<TestRunCoverageStati
     }
 
     private InstrumentingBrowser getLocalBrowser() {
-        if (localBrowser.get() == null) {
-            localBrowser.set(InstrumentingBrowserFactory.newInstance(config));
+    	if (config.getInstrumentingBrowser() != null) {
+    		// Browser is provided by external test runner
+    		return config.getInstrumentingBrowser();
+    	} else {
+    		if (localBrowser.get() == null) {
+        		localBrowser.set(InstrumentingBrowserFactory.newInstance(config));
+        	}
+            return localBrowser.get();
         }
-
-        return localBrowser.get();
     }
 
 }

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/cfg/Config.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/cfg/Config.java
@@ -12,6 +12,7 @@ import com.github.timurstrekalov.saga.core.Order;
 import com.github.timurstrekalov.saga.core.OutputStrategy;
 import com.github.timurstrekalov.saga.core.ReportFormat;
 import com.github.timurstrekalov.saga.core.SortBy;
+import com.github.timurstrekalov.saga.core.instrumentation.InstrumentingBrowser;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -80,6 +81,8 @@ public interface Config {
     void setOrder(String order);
 
     void setWebDriverClassName(String webDriverClassName);
+    
+    void setInstrumentingBrowser(InstrumentingBrowser browser);
 
     void setWebDriverCapabilities(Map<String, String> webDriverCapabilities);
 
@@ -124,6 +127,8 @@ public interface Config {
     Collection<Pattern> getIgnorePatterns();
 
     String getWebDriverClassName();
+    
+    InstrumentingBrowser getInstrumentingBrowser();
 
     Map<String, String> getWebDriverCapabilities();
 

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/cfg/InstanceFieldPerPropertyConfig.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/cfg/InstanceFieldPerPropertyConfig.java
@@ -12,6 +12,7 @@ import com.github.timurstrekalov.saga.core.Order;
 import com.github.timurstrekalov.saga.core.OutputStrategy;
 import com.github.timurstrekalov.saga.core.ReportFormat;
 import com.github.timurstrekalov.saga.core.SortBy;
+import com.github.timurstrekalov.saga.core.instrumentation.InstrumentingBrowser;
 import com.github.timurstrekalov.saga.core.util.UriUtil;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -56,6 +57,7 @@ public class InstanceFieldPerPropertyConfig implements Config {
     private SortBy sortBy = Config.DEFAULT_SORT_BY;
     private Order order = Config.DEFAULT_ORDER;
     private String webDriverClassName = Config.DEFAULT_WEB_DRIVER_CLASS_NAME;
+    private InstrumentingBrowser browser = null;
     private Map<String, String> webDriverCapabilities = Maps.newHashMap();
 
     @Override
@@ -314,10 +316,20 @@ public class InstanceFieldPerPropertyConfig implements Config {
 
         this.webDriverClassName = webDriverClassName;
     }
+    
+    @Override
+    public void setInstrumentingBrowser(final InstrumentingBrowser browser) {
+    	this.browser = browser;
+    }
 
     @Override
     public String getWebDriverClassName() {
         return webDriverClassName;
+    }
+    
+    @Override
+    public InstrumentingBrowser getInstrumentingBrowser() {
+    	return browser;
     }
 
     @Override

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/htmlunit/WebClientFactory.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/htmlunit/WebClientFactory.java
@@ -2,6 +2,7 @@ package com.github.timurstrekalov.saga.core.htmlunit;
 
 import java.io.IOException;
 
+import com.gargoylesoftware.htmlunit.BrowserVersion;
 import com.gargoylesoftware.htmlunit.HttpWebConnection;
 import com.gargoylesoftware.htmlunit.IncorrectnessListener;
 import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
@@ -30,8 +31,15 @@ public final class WebClientFactory {
         throw new UnsupportedOperationException("Factory class");
     }
 
+    // Legacy version of newInstance method
     public static WebClient newInstance(final Config config) {
-        final WebClient client = new WebClient(config.getBrowserVersion()) {
+    	return newInstance(config.getBrowserVersion());
+    }
+    
+    // New version allows for creation of web drivers without the need for a config object
+    // which may not be readily available if the driver is created by third-party code.
+    public static WebClient newInstance(final BrowserVersion version) {
+        final WebClient client = new WebClient(version) {
             @Override
             public WebResponse loadWebResponse(final WebRequest webRequest) throws IOException {
                 return new WebResponseProxy(super.loadWebResponse(webRequest));


### PR DESCRIPTION
This change allows external test runners to integrate more tightly with Saga by providing the IntrumentingBrowser instance to be used for running the tests via the config.  This allows the external test runner to report the test run results when the tests have completed.

This change adds the new config methods set/getInstrumentingBrowser().  If an InstrumentingBrowser instance is provided, then Saga will use it instead of creating its own.  When the test run has completed, the browser will be left open so that the test results can be processed by the external test runner.
