### PR TITLE
First pass at generating cobertura-style output using string templates

### DIFF
--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/DefaultCoverageGenerator.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/DefaultCoverageGenerator.java
@@ -82,6 +82,7 @@ final class DefaultCoverageGenerator implements CoverageGenerator {
         final TestRunCoverageStatistics totalStats = new TestRunCoverageStatistics(baseUri.relativize(URI.create(TOTAL_REPORT_NAME)), "Total coverage report");
         totalStats.setSortBy(config.getSortBy());
         totalStats.setOrder(config.getOrder());
+        totalStats.setSourceDirs(config.getSourceDirs());
 
         maybePreloadSources(totalStats);
         runTests(tests, actualThreadCount, outputStrategy, totalStats);

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/ReportFormat.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/ReportFormat.java
@@ -16,7 +16,18 @@ public enum ReportFormat {
         }
     },
     CSV,
-    PDF;
+    PDF, 
+    COBERTURA {
+    	@Override
+    	public String getSuffix() {
+    		return "coverage";
+    	}
+
+    	@Override
+    	public String getExtension() {
+    		return "xml";
+    	}
+    };
 
     public String getSuffix() {
         return "report";

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/cfg/Config.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/cfg/Config.java
@@ -3,6 +3,7 @@ package com.github.timurstrekalov.saga.core.cfg;
 import java.io.File;
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -25,7 +26,7 @@ public interface Config {
     SortBy DEFAULT_SORT_BY = SortBy.COVERAGE;
     Order DEFAULT_ORDER = Order.DESC;
 
-    Set<ReportFormat> DEFAULT_REPORT_FORMATS = ImmutableSet.of(ReportFormat.HTML, ReportFormat.RAW);
+    Set<ReportFormat> DEFAULT_REPORT_FORMATS = ImmutableSet.of(ReportFormat.HTML, ReportFormat.RAW, ReportFormat.COBERTURA);
 
     String DEFAULT_SOURCES_TO_PRELOAD_ENCODING = "UTF-8";
 
@@ -131,5 +132,9 @@ public interface Config {
     InstrumentingBrowser getInstrumentingBrowser();
 
     Map<String, String> getWebDriverCapabilities();
+
+    void setSourceDir(List<String> sourceDirs);
+
+    List<String> getSourceDirs();
 
 }

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/cfg/InstanceFieldPerPropertyConfig.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/cfg/InstanceFieldPerPropertyConfig.java
@@ -3,6 +3,7 @@ package com.github.timurstrekalov.saga.core.cfg;
 import java.io.File;
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -59,6 +60,8 @@ public class InstanceFieldPerPropertyConfig implements Config {
     private String webDriverClassName = Config.DEFAULT_WEB_DRIVER_CLASS_NAME;
     private InstrumentingBrowser browser = null;
     private Map<String, String> webDriverCapabilities = Maps.newHashMap();
+
+    private List<String> sourceDirs;
 
     @Override
     public void setBaseDir(final String baseDir) {
@@ -359,6 +362,16 @@ public class InstanceFieldPerPropertyConfig implements Config {
     @Override
     public Map<String, String> getWebDriverCapabilities() {
         return webDriverCapabilities;
+    }
+
+    @Override
+    public void setSourceDir(List<String> sourceDirs) {
+        this.sourceDirs = sourceDirs;
+    }
+
+    @Override
+    public List<String> getSourceDirs() {
+        return sourceDirs;
     }
 
 }

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/model/ScriptCoverageStatistics.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/model/ScriptCoverageStatistics.java
@@ -82,6 +82,10 @@ public final class ScriptCoverageStatistics {
         return MiscUtil.toCoverage(getStatements(), getExecuted());
     }
 
+    public double getCoverageRate() {
+        return MiscUtil.toCoverageRate(getStatements(), getExecuted());
+    }
+
     public boolean getHasStatements() {
         return getStatements() > 0;
     }

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/model/TestRunCoverageStatistics.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/model/TestRunCoverageStatistics.java
@@ -33,6 +33,8 @@ public final class TestRunCoverageStatistics implements Iterable<ScriptCoverageS
 
     private final Map<URI, ScriptCoverageStatistics> fileStatsMap = Maps.newTreeMap();
 
+    private List<String> sourceDirs;
+
     public TestRunCoverageStatistics(final URI test) {
         this(test, String.format("Coverage report for \"%s\"", test));
     }
@@ -103,6 +105,10 @@ public final class TestRunCoverageStatistics implements Iterable<ScriptCoverageS
         return MiscUtil.toCoverage(getTotalStatements(), getTotalExecuted());
     }
 
+    public double getTotalCoverageRate() {
+        return MiscUtil.toCoverageRate(getTotalStatements(), getTotalExecuted());
+    }
+
     public boolean getHasStatements() {
         return getTotalStatements() > 0;
     }
@@ -134,6 +140,14 @@ public final class TestRunCoverageStatistics implements Iterable<ScriptCoverageS
 
     public Order getOrder() {
         return order;
+    }
+
+    public void setSourceDirs(List<String> sourceDirs) {
+        this.sourceDirs = sourceDirs;
+    }
+
+    public List<String> getSourceDirs(){
+        return sourceDirs;
     }
 
 }

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/reporter/CoberturaReporter.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/reporter/CoberturaReporter.java
@@ -1,0 +1,25 @@
+package com.github.timurstrekalov.saga.core.reporter;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.github.timurstrekalov.saga.core.ReportFormat;
+import com.github.timurstrekalov.saga.core.model.TestRunCoverageStatistics;
+
+public class CoberturaReporter extends AbstractStringTemplateBasedReporter {
+
+    public CoberturaReporter() {
+        super(ReportFormat.COBERTURA);
+    }
+
+    @Override
+    protected void writeReportThreadSafe(final File outputFile, final TestRunCoverageStatistics runStats) throws IOException {
+        stringTemplateGroup.getInstanceOf("runStatsCobertura")
+                .add("stats", runStats)
+                .add("name", config.getProperty("app.name"))
+                .add("version", config.getProperty("app.version"))
+                .add("url", config.getProperty("app.url"))
+                .write(outputFile, listener);
+    }
+
+}

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/reporter/ReporterFactory.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/reporter/ReporterFactory.java
@@ -12,6 +12,7 @@ public final class ReporterFactory {
             .put(ReportFormat.RAW, RawReporter.class)
             .put(ReportFormat.CSV, CsvReporter.class)
             .put(ReportFormat.PDF, PdfReporter.class)
+            .put(ReportFormat.COBERTURA, CoberturaReporter.class)
             .build();
 
     private ReporterFactory() {

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/util/MiscUtil.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/util/MiscUtil.java
@@ -19,7 +19,11 @@ public final class MiscUtil {
     }
 
     public static int toCoverage(final int totalStatements, final int totalExecuted) {
-        return (int) ((double) totalExecuted / totalStatements * 100);
+        return (int) toCoverageRate(totalStatements, totalExecuted) * 100;
+    }
+
+    public static double toCoverageRate(final int totalStatements, final int totalExecuted) {
+        return (double) totalExecuted / totalStatements;
     }
 
     public static <T> int sum(final Iterable<T> objects, final Function<T, Integer> transformer) {

--- a/saga-core/src/main/resources/stringTemplates/classStatsCobertura.st
+++ b/saga-core/src/main/resources/stringTemplates/classStatsCobertura.st
@@ -1,0 +1,8 @@
+classStatsCobertura(fileStats) ::= <<
+<class name="$fileStats.fileName$" filename="$fileStats.relativeName$" line-rate="$fileStats.coverageRate$" branch-rate="0.0" complexity="0">
+	<methods />
+	<lines>
+		$fileStats.executableLineCoverageRecords:lineCoverageDataCobertura(); separator="\n"$
+	</lines>
+</class>
+>>

--- a/saga-core/src/main/resources/stringTemplates/lineCoverageDataCobertura.st
+++ b/saga-core/src/main/resources/stringTemplates/lineCoverageDataCobertura.st
@@ -1,0 +1,3 @@
+lineCoverageDataCobertura(lineStats) ::= <<
+<line number="$lineStats.lineNr$" hits="$lineStats.timesExecuted$" branch="false"/>
+>>

--- a/saga-core/src/main/resources/stringTemplates/packageStatsCobertura.st
+++ b/saga-core/src/main/resources/stringTemplates/packageStatsCobertura.st
@@ -1,0 +1,7 @@
+packageStatsCobertura(fileStats) ::= <<
+<package name="$fileStats.relativeName$" line-rate="0.0" branch-rate="0.0" complexity="0">
+<classes>
+</classes>
+</package>
+
+>>

--- a/saga-core/src/main/resources/stringTemplates/runStatsCobertura.st
+++ b/saga-core/src/main/resources/stringTemplates/runStatsCobertura.st
@@ -1,0 +1,18 @@
+runStatsCobertura(stats, name, version, url) ::= <<
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>
+<!-- Generated using $name$ ($url$) version $version$ -->
+<coverage branch-rate="0.0" branches-covered="0" branches-valid="0" complexity="0" line-rate="$stats.totalCoverageRate$" lines-valid="$stats.totalStatements$" lines-covered="$stats.totalExecuted$" timestamp="1376875707" version="1.9">
+	<sources>
+		$stats.sourceDirs:sourceDirsCobertura(); separator="\n"$
+	</sources>
+	<packages>
+		<package name="default" line-rate="0.0" branch-rate="0.0" complexity="0">
+			<classes>
+				$stats.fileStatsWithSeparateFileOnly:classStatsCobertura(); separator="\n"$
+			</classes>
+		</package>
+	</packages>
+</coverage>
+
+>>

--- a/saga-core/src/main/resources/stringTemplates/sourceDirsCobertura.st
+++ b/saga-core/src/main/resources/stringTemplates/sourceDirsCobertura.st
@@ -1,0 +1,3 @@
+sourceDirsCobertura(sourceDir) ::= <<
+<source>$sourceDir$</source>
+>>

--- a/saga-maven-plugin/src/main/java/com/github/timurstrekalov/saga/maven/SagaMojo.java
+++ b/saga-maven-plugin/src/main/java/com/github/timurstrekalov/saga/maven/SagaMojo.java
@@ -1,6 +1,7 @@
 package com.github.timurstrekalov.saga.maven;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 
 import com.github.timurstrekalov.saga.core.CoverageGenerator;
@@ -130,9 +131,10 @@ public class SagaMojo extends AbstractMojo {
      *     <li>RAW</li>
      *     <li>CSV</li>
      *     <li>PDF</li>
+     *     <li>COBERTURA</li>
      * </ul>
      */
-    @Parameter(defaultValue = "HTML, RAW")
+    @Parameter(defaultValue = "HTML, RAW, COBERTURA")
     private String reportFormats;
 
     /**
@@ -174,6 +176,12 @@ public class SagaMojo extends AbstractMojo {
     @Parameter
     private Map<String, String> webDriverCapabilities;
 
+    /**
+     * Absolute path to the sources.  This is used when generating COBERTURA style reports.
+     */
+    @Parameter
+    private List<String> sourceDirs;
+
     @Override
     public void execute() throws MojoExecutionException {
         if (skipTests) {
@@ -202,6 +210,7 @@ public class SagaMojo extends AbstractMojo {
             config.setOrder(order);
             config.setWebDriverCapabilities(webDriverCapabilities);
             config.setWebDriverClassName(webDriverClassName);
+            config.setSourceDir(sourceDirs);
 
             gen.instrumentAndGenerateReports();
         } catch (final IllegalArgumentException e) {


### PR DESCRIPTION
These changes are by no means complete, but I wanted to get some feedback on them before continuing development.  I know the ultimate goal for Saga is to get away from string templates for reports, however, I think using string templates to generate the cobertura report for now is much simpler.

One key bit of work that still remains is to group the files by package/directory so the results are easier to look at.  Currently, all files will end up in a default package.

One other change I had to make but didn't like was adding a "sourceDirs" property to the configuration in for the maven integration.  I couldn't find any other good way to populate the source directories in the cobertura report, especially when Saga was running with Jasmine, where all sources appear to come from http://localhost:1234

I would also like to be able to generate complexity statistics, method coverage, and branch coverage in the future, but that's going to rely on other work to get those stats from the coverage generators.

If this seems like a good start, I can continue the work to group the coverage by package/directory.
