### PR TITLE
update plugin and dependency versions

### DIFF
--- a/gradle-saga-plugin/build.gradle
+++ b/gradle-saga-plugin/build.gradle
@@ -37,7 +37,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    groovy group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.0.1'
+    groovy group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.1.9'
 
     compile group: 'com.github.timurstrekalov', name: 'saga-core', version: projectVersion
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.0</version>
+                    <version>3.1</version>
                     <configuration>
                         <source>1.6</source>
                         <target>1.6</target>
@@ -76,7 +76,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.14.1</version>
+                    <version>2.16</version>
                     <executions>
                         <execution>
                             <id>integration-test</id>
@@ -110,12 +110,12 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>14.0</version>
+                <version>15.0</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.0.9</version>
+                <version>1.0.13</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -150,7 +150,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>3.0.10</version>
+                <version>3.0.15</version>
             </dependency>
 
             <dependency>

--- a/saga-core/pom.xml
+++ b/saga-core/pom.xml
@@ -11,8 +11,8 @@
     <artifactId>saga-core</artifactId>
 
     <properties>
-        <jetty.version>8.1.10.v20130312</jetty.version>
-        <selenium.version>2.32.0</selenium.version>
+        <jetty.version>8.1.14.v20131031</jetty.version>
+        <selenium.version>2.37.1</selenium.version>
     </properties>
 
     <build>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.12</version>
+            <version>2.13</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.itextpdf</groupId>
             <artifactId>itextpdf</artifactId>
-            <version>5.4.0</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>com.github.detro.ghostdriver</groupId>
             <artifactId>phantomjsdriver</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.4</version>
         </dependency>
     </dependencies>
 
@@ -123,7 +123,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.5.2</version>
+                        <version>2.6</version>
                         <configuration>
                             <instrumentation>
                                 <excludes>

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/instrumentation/GenericInstrumentingBrowser.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/instrumentation/GenericInstrumentingBrowser.java
@@ -110,7 +110,7 @@ public class GenericInstrumentingBrowser implements InstrumentingBrowser {
         final Proxy proxy = new Proxy()
                 .setProxyType(Proxy.ProxyType.MANUAL)
                 .setHttpProxy(proxyUrl)
-                .setHttpsProxy(proxyUrl);
+                .setSslProxy(proxyUrl);
 
         final DesiredCapabilities desiredCapabilities = new DesiredCapabilities(config.getWebDriverCapabilities());
         desiredCapabilities.setCapability(CapabilityType.PROXY, proxy);

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/model/ScriptCoverageStatistics.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/model/ScriptCoverageStatistics.java
@@ -2,6 +2,7 @@ package com.github.timurstrekalov.saga.core.model;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.List;
 
@@ -44,7 +45,7 @@ public final class ScriptCoverageStatistics {
     }
 
     private String generateId() {
-        return Hashing.md5().hashString(fileUri.toString()).toString();
+        return Hashing.md5().hashString(fileUri.toString(), Charset.defaultCharset()).toString();
     }
 
     public List<LineCoverageRecord> getLineCoverageRecords() {

--- a/saga-core/src/test/java/com/github/timurstrekalov/saga/core/instrumentation/InstrumentingProxyServerIT.java
+++ b/saga-core/src/test/java/com/github/timurstrekalov/saga/core/instrumentation/InstrumentingProxyServerIT.java
@@ -44,7 +44,7 @@ public class InstrumentingProxyServerIT {
         final Proxy proxy = new Proxy()
                 .setProxyType(Proxy.ProxyType.MANUAL)
                 .setHttpProxy(proxyUrl)
-                .setHttpsProxy(proxyUrl);
+                .setSslProxy(proxyUrl);
 
         final DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
         desiredCapabilities.setCapability(CapabilityType.PROXY, proxy);

--- a/saga-maven-plugin/pom.xml
+++ b/saga-maven-plugin/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.0.4</version>
+            <version>3.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
This PR contains the following changes:
- update dependency versions: not I only did a minor update of the maven-plugin-api (to 3.0.5 and not upgrade to 3.1.1)
- update plugin versions
- fix a deprecation in ScriptCoverageStatistics; related to updating Guava
- fix previously deprecated, now missing Proxy.setHttpsProxy(...) in GenericInstrumentingBrowser and InstrumentingProxyServerIT; related to updating Selenium
