### PR TITLE
Fixing HTMLUnit ignores noInstrumentPatterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.iml
+.idea
+out
+
+build
+target
+.gradle
+*.log


### PR DESCRIPTION
Instrumenting using the phantomJS driver ignores noInstrumentPatterns.

I'm using saga-maven-plugin with jasmine-maven-plugin and keepServerAlive. My webdriver is set to org.openqa.selenium.phantomjs.PhantomJSDriver. my noInstrumentPatterns are simply ignored. This patch fixes that.
