### PR TITLE
support for phantomjs running

### DIFF
--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/instrumentation/HtmlUnitBasedScriptInstrumenter.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/instrumentation/HtmlUnitBasedScriptInstrumenter.java
@@ -61,7 +61,7 @@ public final class HtmlUnitBasedScriptInstrumenter implements ScriptInstrumenter
     }
 
     @Override
-    public String instrument(final String sourceCode, final String sourceName, final int lineNumber) {
+    synchronized public String instrument(final String sourceCode, final String sourceName, final int lineNumber) {
         try {
             final String normalizedSourceName = handleEvals(handleInvalidUriChars(handleInlineScripts(sourceName)));
 

--- a/saga-core/src/main/java/com/github/timurstrekalov/saga/core/model/ScriptData.java
+++ b/saga-core/src/main/java/com/github/timurstrekalov/saga/core/model/ScriptData.java
@@ -92,7 +92,7 @@ public final class ScriptData {
             for (int lineNr = getLineNumberOfFirstStatement(); in.hasNext(); lineNr++) {
                 final String line = in.nextLine();
 
-                final Long coverageEntry = coverageData.get(String.valueOf(lineNr));
+                final Long coverageEntry = (coverageData==null ? null : coverageData.get(String.valueOf(lineNr)));
                 final int timesLineExecuted;
 
                 if (coverageEntry == null) {


### PR DESCRIPTION
There were some synchronization issues with phantomjs, these were fixed in HtmlUnitBasedScriptInstrumenter.java and ScriptData.java

I also added better support for jasmine-maven-plugin if it was executed with phantomjs.
If you use jasmine with phatnomjs it runs the tests through a webserver, and saga also
used this server to calculate coverage. Because of this, total coverage report was not possible,
since it saw only the files tested by jasmine.
To solve this, I expanded FileSystemSourcePreloader.java. If sourceDirs is defined in pom.xml, then it is used as full source directory.
