### PR TITLE
add compatibility with jasmine-maven-plugin 2.0

### DIFF
--- a/saga-core/src/main/resources/completion_monitor.js
+++ b/saga-core/src/main/resources/completion_monitor.js
@@ -4,7 +4,8 @@
     if (!saga.completed) {
         saga.completed = function() {
             function detectJasmineCompletion() {
-                return window.reporter && window.reporter.finished;
+                return (window.reporter && window.reporter.finished) ||
+                    (window.jsApiReporter && window.jsApiReporter.finished);
             }
 
             // this space reserved for detecting completeness for other frameworks


### PR DESCRIPTION
New major version of maven plugin changed the name of `reporter` object.
Also there is a related issue https://github.com/searls/jasmine-maven-plugin/issues/285